### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -6,8 +6,8 @@ jobs:
     name: Markdownlint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: nosborn/github-action-markdown-cli@v3.5.0
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: nosborn/github-action-markdown-cli@9bfd0452ce630f6469986587db7f0feab5b22273 # v3.5.0
       name: Markdownlint
       with:
         files: .

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -6,6 +6,6 @@ jobs:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.58.0
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: rojopolis/spellcheck-github-actions@0bf4b2f91efa259b52c202b09b0c3845c524ff36 # 0.58.0
       name: Spellcheck


### PR DESCRIPTION
## Summary
This PR pins all GitHub Actions used in workflows to specific commit SHAs instead of mutable tags, improving security by preventing potential supply chain attacks.

## Changes
- **actions/checkout**: Pinned from `@master` to `@8e8c483` (v6.0.1)
- **nosborn/github-action-markdown-cli**: Pinned to `@9bfd045` (v3.5.0)
- **rojopolis/spellcheck-github-actions**: Pinned to `@0bf4b2f` (0.58.0)

All pinned versions include human-readable version comments (`# vX.X.X`) for easy reference.

## Benefits
- **Security**: Commit SHAs are immutable, preventing tampering with action code
- **Reliability**: Ensures consistent behavior across workflow runs
- **Maintainability**: Version comments make it easy to identify what version is being used
- **Dependabot-friendly**: Dependabot can automatically update pinned actions and maintain version comments